### PR TITLE
Added tabbing classes and styles.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,18 +1,26 @@
 import React, { Component } from 'react';
-import logo from './logo.svg';
-import './App.css';
+//import logo from './logo.svg';
+//import './App.css';
+
+import Tabs from './Tabs';
+require('./styles.css');
 
 class App extends Component {
   render() {
     return (
-      <div className="App">
-        <header className="App-header">
-          <img src={logo} className="App-logo" alt="logo" />
-          <h1 className="App-title">Welcome to React</h1>
-        </header>
-        <p className="App-intro">
-          To get started, edit <code>src/App.js</code> and save to reload.
-        </p>
+      <div>
+        <h1>Character Sheet</h1>
+        <Tabs>
+          <div label="Character">
+            Character info goes here.
+          </div>
+          <div label="Stats">
+            Stats info goes here.
+          </div>
+          <div label="Combat">
+            Combat info goes here.
+          </div>
+        </Tabs>
       </div>
     );
   }

--- a/src/Tab.js
+++ b/src/Tab.js
@@ -1,0 +1,44 @@
+// Taken initially from https://alligator.io/react/tabs-component/
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+class Tab extends Component {
+    static propTypes = {
+        activeTab: PropTypes.string.isRequired,
+        label: PropTypes.string.isRequired,
+        onClick: PropTypes.func.isRequired,
+    };
+
+    onClick = () => {
+        const { label, onClick } = this.props;
+        onClick(label);
+    }
+
+    render() {
+        const {
+            onClick,
+            props: {
+                activeTab,
+                label,
+            },
+        } = this;
+
+        let className = 'tab-list-item';
+
+        if (activeTab === label) {
+            className += ' tab-list-active';
+        }
+
+        return (
+            <li
+                className={className}
+                onClick={onClick}
+            >
+                {label}
+            </li>
+        );
+    }
+}
+
+export default Tab;

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -1,0 +1,64 @@
+// Initially based on this guide: https://alligator.io/react/tabs-component/
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import Tab from './Tab';
+
+class Tabs extends Component {
+    static propTypes = {
+        children: PropTypes.instanceOf(Array).isRequired,
+    }
+
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            activeTab: this.props.children[0].props.label,
+        };
+    }
+
+    onClickTabItem = (tab) => {
+        this.setState({ activeTab: tab });
+    }
+
+    render() {
+        const {
+            onClickTabItem,
+            props: {
+                children,
+            },
+            state: {
+                activeTab
+            }
+        } = this;
+
+        return (
+            <div className="tabs">
+            <ol className="tab-list">
+            {children.map((child) => {
+                const { label } = child.props;
+
+                return (
+                <Tab
+                    activeTab={activeTab}
+                    key={label}
+                    label={label}
+                    onClick={onClickTabItem}
+                />
+                );
+            })}
+            </ol>
+            <div className="tab-content">
+            {children.map((child) => {
+                if (child.props.label !== activeTab) return undefined;
+                return child.props.children;
+            })}
+            </div>
+        </div>
+        );
+    }
+}
+
+export default Tabs;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,31 @@
+.tab-list {
+    float: left;
+    border-bottom: 1px solid #ccc;
+    padding-left: 0;
+    width: 10%;
+}
+
+.tab-list-active {
+    background-color: gray;
+    color: white;
+    border: solid rgb(5, 5, 5);
+    border-width: 1px 1px 0 1px;
+}
+
+.tab-list-item {
+    display: block;
+    list-style: none;
+    margin-bottom: -1px;
+    padding: 0.5rem 0.75rem;
+    border: solid rgb(5,5,5);
+    border-width: 1px 1px 0 1px;
+}
+
+.tab-content {
+    float: left;
+    padding: 1.0rem 0.75rem;
+    border: solid rgb(5, 5, 5);
+    border-width: 2px 2px 2px 2px;
+    margin-top: 16px;
+    width: 80%;
+}


### PR DESCRIPTION
I pulled this tabbing stuff pretty directly from the site mentioned in the comments of `Tab.js` and `Tabs.js`. The CSS I changed a fair amount, however, in experimenting with getting the tabs to lay vertically to the left of the tabbed page content.

I'd be interested to know if this seems extensible for more complicated elements in each tab, i.e. if putting more than simple text in each tab-content page will show limitations of what I've pulled here.