### PR TITLE
Add edit mode and name change

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,12 +2,41 @@ import React, { Component } from 'react';
 import './App.css';
 
 import MenuAppBar from './Bar';
+import Sheet from './Sheet';
+
+
 
 class App extends Component {
+  state = {
+    isEditing: false,
+    charName: "",
+  }
+
+  handleEdit = () => {
+    this.state.isEditing ? (
+      this.setState({ isEditing: false })
+    ) : (
+      this.setState({ isEditing: true })
+   )}
+
+  handleNameChange = (name) => {
+    this.setState({ charName: name });
+  };
+
   render() {
+      const { isEditing, charName } = this.state;
+
     return (
       <div className="App">
-        <MenuAppBar/>
+        <MenuAppBar
+          isEditing={isEditing}
+          charName={charName}
+          onEditToggle={this.handleEdit}
+        />
+        <Sheet
+          isEditing={isEditing}
+          onNameChange={this.handleNameChange}
+        />
       </div>
     );
   }

--- a/src/Bar.js
+++ b/src/Bar.js
@@ -10,6 +10,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import Menu from '@material-ui/core/Menu';
 import { Avatar } from '@material-ui/core';
 import AddAPhotoIcon from '@material-ui/icons/AddAPhoto'
+import Edit from '@material-ui/icons/Edit'
 
 const styles = {
   root: {
@@ -43,12 +44,12 @@ class MenuAppBar extends React.Component {
     this.setState({ anchorEl: null });
   };
 
-  charNameUpdate = (text) => {
-      this.setState({ charName: text})
-  };
+  handleEditClick = () => {
+    this.props.onEditToggle();
+  }
 
   render() {
-    const { classes } = this.props;
+    const { classes, charName } = this.props;
     const { auth, anchorEl } = this.state;
     const open = Boolean(anchorEl);
 
@@ -60,9 +61,11 @@ class MenuAppBar extends React.Component {
               <MenuIcon />
             </IconButton>
             <Typography variant="title" color="inherit" className={classes.flex}>
-              {this.state.charName}
-              onClick={this.charNameUpdate}
+              {charName}
             </Typography>
+            <IconButton color="inherit" onClick={this.handleEditClick}>
+               <Edit />
+            </IconButton>
             {auth && (
               <div>
                 <IconButton
@@ -71,9 +74,9 @@ class MenuAppBar extends React.Component {
                   onClick={this.handleMenu}
                   color="inherit"
                 >
-                  <Avatar className={classes.avatar}>
-                    <AddAPhotoIcon/>
-                  </Avatar>
+                <Avatar className={classes.avatar}>
+                  <AddAPhotoIcon/>
+                </Avatar>
                 </IconButton>
                 <Menu
                   id="menu-appbar"

--- a/src/Sheet.js
+++ b/src/Sheet.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
+import Grid from '@material-ui/core/Grid';
+import TextField from '@material-ui/core/TextField';
+
+const styles = theme => ({
+  root: {
+    flexGrow: 1,
+  },
+  paper: {
+    padding: theme.spacing.unit * 2,
+    textAlign: 'center',
+    color: theme.palette.text.secondary,
+  },
+});
+
+class Sheet extends React.Component {
+  handleNameChange = event => {
+    this.props.onNameChange(event.target.value);
+  };
+
+  render() {
+    const { classes } = this.props;
+
+    return (
+      <div className={classes.root}>
+        <Grid container spacing={24}>
+          <Grid item xs={3}>
+            {this.props.isEditing &&
+             <TextField
+             id="name"
+             label="Name"
+             value={this.props.charName}
+             colors="inherit"
+             className={classes.textField}
+             onChange={this.handleNameChange}
+             margin="normal"
+             />
+            }
+          </Grid>
+          <Grid item xs={3}>
+          </Grid>
+          <Grid item xs={6}>
+          </Grid>
+
+        {/*
+          <Grid item xs={6}>
+            <Paper className={classes.paper}>xs=6</Paper>
+          </Grid>
+          <Grid item xs={6}>
+            <Paper className={classes.paper}>xs=6</Paper>
+          </Grid>
+          <Grid item xs={3}>
+            <Paper className={classes.paper}>xs=3</Paper>
+          </Grid>
+          <Grid item xs={3}>
+            <Paper className={classes.paper}>xs=3</Paper>
+          </Grid>
+          <Grid item xs={3}>
+            <Paper className={classes.paper}>xs=3</Paper>
+          </Grid>
+          <Grid item xs={3}>
+            <Paper className={classes.paper}>xs=3</Paper>
+          </Grid>
+         */}
+
+        </Grid>
+      </div>
+    );
+  }
+}
+
+Sheet.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(Sheet);


### PR DESCRIPTION
Add an edit button that sets an edit mode. When edit mode is set, a field to edit the character name will show up. The name displayed on the MenuBar updates as the name is entered.

I lifted `charName` to the App component. I also added `isEditing`, which is used to conditionally render a `TextField` where the character name is entered. 

I also added a new `Sheet` component in the character sheet area. The name is a bit generic, and we should probably get more specific as we add more pages. It also has some grid rows commented out as a reference since we may be able to use some of that.